### PR TITLE
Add support for structures as world spawn

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modCompile "net.fabricmc:fabric-loader:${project.loader_version}"
+	modCompile "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modCompile "net.fabricmc:fabric-loader:${project.loader_version}"
-	modCompile "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,14 +5,11 @@ minecraft_version=1.16.1
 yarn_mappings=1.16.1+build.21
 loader_version=0.9.0+build.204
 
-#Fabric api
-fabric_version=0.16.0+build.384-1.16.1
-
 # Mod Properties
-	mod_version = 1.0.0
-	maven_group = protosky
-	archives_base_name = protosky
+mod_version = 1.0.0
+maven_group = protosky
+archives_base_name = protosky
 
 # Dependencies
-	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	# fabric_version=0.10.2+build.337-1.16
+# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
+# fabric_version=0.10.2+build.337-1.16

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,12 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-# Fabric Properties
-	# check these on https://fabricmc.net/use or https://modmuss50.me/fabric.html
-	minecraft_version=1.16.1
-	yarn_mappings=1.16.1+build.20
-	loader_version=0.8.9+build.203
+minecraft_version=1.16.1
+yarn_mappings=1.16.1+build.21
+loader_version=0.9.0+build.204
+
+#Fabric api
+fabric_version=0.16.0+build.384-1.16.1
 
 # Mod Properties
 	mod_version = 1.0.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sat Jul 25 02:10:56 CEST 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/protosky/gen/StructureHelper.java
+++ b/src/main/java/protosky/gen/StructureHelper.java
@@ -16,7 +16,6 @@ import net.minecraft.world.*;
 import net.minecraft.world.chunk.ChunkStatus;
 import net.minecraft.world.chunk.ProtoChunk;
 import net.minecraft.world.gen.feature.EndSpikeFeature;
-import net.minecraft.world.gen.feature.Feature;
 import net.minecraft.world.gen.feature.StructureFeature;
 import protosky.mixins.StructurePieceAccessor;
 

--- a/src/main/java/protosky/gen/WorldGenUtils.java
+++ b/src/main/java/protosky/gen/WorldGenUtils.java
@@ -51,8 +51,6 @@ public class WorldGenUtils
 
         if (world.getRegistryKey() == World.END)
             StructureHelper.generatePillars(chunk, world, world.getEnderDragonFight());
-
-        Heightmap.populateHeightmaps(chunk, EnumSet.allOf(Heightmap.Type.class));
     }
 
 

--- a/src/main/java/protosky/gen/WorldGenUtils.java
+++ b/src/main/java/protosky/gen/WorldGenUtils.java
@@ -1,15 +1,20 @@
 package protosky.gen;
 
+import com.google.common.collect.ImmutableList;
 import net.minecraft.block.BlockState;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtHelper;
+import net.minecraft.server.network.SpawnLocating;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.structure.Structure;
 import net.minecraft.structure.StructureManager;
+import net.minecraft.structure.StructurePlacementData;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.collection.PackedIntegerArray;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.ChunkRegion;
 import net.minecraft.world.Heightmap;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldAccess;
@@ -17,6 +22,7 @@ import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkSection;
 import net.minecraft.world.chunk.ProtoChunk;
 import net.minecraft.world.chunk.WorldChunk;
+import net.minecraft.world.gen.chunk.ChunkGenerator;
 import protosky.mixins.ProtoChunkAccessor;
 
 import java.util.*;
@@ -74,43 +80,7 @@ public class WorldGenUtils
         if (s == null) return;
         CompoundTag t = new CompoundTag();
 
-        // s.place would call world.getChunk, causing it to hang.
-        // Hence, I've reimplemented spawning a structure.
-        // The limitation here is that the structure is limited to 16 blocks,
-        // and assumes it centers around (8, 0, 8).
-        // Other limitations for this implementation are:
-        // - No support for BlockEntities
-        // - No support for Entities
-        // Additionally, this platform is spawned at Y=64 with no way to configure this.
-
-        s.toTag(t);
-
-        // Collect the palette
-        Map<Integer, BlockState> map = new HashMap<>();
-        ListTag palette = t.getList("palette", 10);
-        for (int i = 0; i < palette.size(); i++) {
-            CompoundTag e = palette.getCompound(i);
-            map.put(i, NbtHelper.toBlockState(e));
-        }
-        BlockPos.Mutable relStart = chunk.getPos().getCenterBlockPos().mutableCopy();
-        relStart.setY(64);
-
-        // Place the blocks in the chunk
-        BlockPos highest = BlockPos.ORIGIN;
-        ListTag blocks = t.getList("blocks", 10);
-        for (int i = 0; i < blocks.size(); i++) {
-            CompoundTag b = blocks.getCompound(i);
-            BlockState st = map.get(b.getInt("state"));
-            ListTag t2 = b.getList("pos", 3);
-            BlockPos p = relStart.add(new BlockPos(t2.getInt(0), t2.getInt(1), t2.getInt(2)));
-            if (p.getY() > highest.getY()) {
-                highest = p;
-            }
-            chunk.setBlockState(p, st, false);
-        }
-
-        // Because of the way we spawn the structure, it's common to fall into the void next to it.
-        // As solution, we simply set the world spawn on top of said structure.
-        world.setSpawnPos(highest.up());
+        s.place(new ChunkRegion(world, ImmutableList.of(chunk)), chunk.getPos().toBlockPos(0,64,0), new StructurePlacementData().setUpdateNeighbors(true), new Random());
+        world.setSpawnPos(chunk.getPos().toBlockPos(s.getSize().getX() / 2, 64 + s.getSize().getY() + 1, s.getSize().getZ() / 2));
     }
 }

--- a/src/main/java/protosky/gen/WorldGenUtils.java
+++ b/src/main/java/protosky/gen/WorldGenUtils.java
@@ -1,25 +1,15 @@
 package protosky.gen;
 
-import net.fabricmc.fabric.api.util.NbtType;
-import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
-import net.minecraft.block.StonecutterBlock;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtHelper;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.state.StateManager;
-import net.minecraft.state.property.Property;
 import net.minecraft.structure.Structure;
 import net.minecraft.structure.StructureManager;
-import net.minecraft.structure.StructurePlacementData;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.collection.PackedIntegerArray;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Vec3d;
-import net.minecraft.util.math.Vec3i;
-import net.minecraft.util.registry.Registry;
 import net.minecraft.world.Heightmap;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldAccess;
@@ -97,7 +87,7 @@ public class WorldGenUtils
 
         // Collect the palette
         Map<Integer, BlockState> map = new HashMap<>();
-        ListTag palette = t.getList("palette", NbtType.COMPOUND);
+        ListTag palette = t.getList("palette", 10);
         for (int i = 0; i < palette.size(); i++) {
             CompoundTag e = palette.getCompound(i);
             map.put(i, NbtHelper.toBlockState(e));
@@ -107,11 +97,11 @@ public class WorldGenUtils
 
         // Place the blocks in the chunk
         BlockPos highest = BlockPos.ORIGIN;
-        ListTag blocks = t.getList("blocks", NbtType.COMPOUND);
+        ListTag blocks = t.getList("blocks", 10);
         for (int i = 0; i < blocks.size(); i++) {
             CompoundTag b = blocks.getCompound(i);
             BlockState st = map.get(b.getInt("state"));
-            ListTag t2 = b.getList("pos", NbtType.INT);
+            ListTag t2 = b.getList("pos", 3);
             BlockPos p = relStart.add(new BlockPos(t2.getInt(0), t2.getInt(1), t2.getInt(2)));
             if (p.getY() > highest.getY()) {
                 highest = p;

--- a/src/main/java/protosky/mixins/ChunkStatusMixin.java
+++ b/src/main/java/protosky/mixins/ChunkStatusMixin.java
@@ -4,6 +4,7 @@ import net.minecraft.server.world.ServerLightingProvider;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.structure.StructureManager;
 import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.Heightmap;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkStatus;
 import net.minecraft.world.chunk.ProtoChunk;
@@ -15,6 +16,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import protosky.gen.WorldGenUtils;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.function.Function;
 
@@ -30,6 +32,7 @@ public abstract class ChunkStatusMixin
             if (new ChunkPos(world.getSpawnPos()).equals(chunk.getPos())) {
                 WorldGenUtils.genSpawnPlatform(chunk, world);
             }
+            Heightmap.populateHeightmaps(chunk, EnumSet.of(Heightmap.Type.MOTION_BLOCKING, Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, Heightmap.Type.OCEAN_FLOOR, Heightmap.Type.WORLD_SURFACE));
         }
     }
     

--- a/src/main/java/protosky/mixins/ChunkStatusMixin.java
+++ b/src/main/java/protosky/mixins/ChunkStatusMixin.java
@@ -3,6 +3,7 @@ package protosky.mixins;
 import net.minecraft.server.world.ServerLightingProvider;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.structure.StructureManager;
+import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkStatus;
 import net.minecraft.world.chunk.ProtoChunk;
@@ -24,8 +25,12 @@ public abstract class ChunkStatusMixin
     @Inject(method = "method_20613", at = @At("HEAD"))
     private static void onLighting(ChunkStatus chunkStatus, ServerWorld world, ChunkGenerator generator, StructureManager manager, ServerLightingProvider lightingProvider, Function function, List list, Chunk chunk, CallbackInfoReturnable info)
     {
-        if(!chunk.getStatus().isAtLeast(chunkStatus))
+        if(!chunk.getStatus().isAtLeast(chunkStatus)) {
             WorldGenUtils.deleteBlocks((ProtoChunk) chunk, world);
+            if (new ChunkPos(world.getSpawnPos()).equals(chunk.getPos())) {
+                WorldGenUtils.genSpawnPlatform(chunk, world);
+            }
+        }
     }
     
     // SPAWN -> populateEntities


### PR DESCRIPTION
To create a spawn structure, simply put a structure NBT file (generated by Structure blocks or similar) in a datapack as `protosky:spawn_overworld` or `protosky:spawn_nether` depending on the dimension you want to create a spawn platform for.

The main goal of this PR is to allow modpack devs to create their own custom spawn islands for their skyblock packs.